### PR TITLE
tech(out-of-scope): add out of scope images

### DIFF
--- a/out-of-scope.md
+++ b/out-of-scope.md
@@ -1,9 +1,25 @@
 # Out of Scope
 
 ### Auto Complete
+<img width="660" alt="image" src="https://user-images.githubusercontent.com/29545937/156362587-a507881e-2d27-4780-9f31-f7a250f7540a.png">
+
 ### Sticky Header
+<img width="1436" alt="image" src="https://user-images.githubusercontent.com/29545937/156362736-23aedb43-6cc1-40a0-acf1-b7cd082ff1de.png">
+
 ### Search Result Page Tabs
+<img width="725" alt="image" src="https://user-images.githubusercontent.com/29545937/156362775-1bf83c95-454e-49c8-b575-22bd4024a931.png">
+
 ### Related searches
+<img width="734" alt="image" src="https://user-images.githubusercontent.com/29545937/156362934-023beed5-f8f6-4848-99ce-295eb89ac2f5.png">
+
 ### User View
+<img width="207" alt="image" src="https://user-images.githubusercontent.com/29545937/156362970-a3f3f05c-2677-4594-8b8f-c1d83215a722.png">
+
 ### Mic
+<img width="95" alt="image" src="https://user-images.githubusercontent.com/29545937/156363009-4c2c33a3-d6c4-4b70-b80e-6d790286a715.png">
+
 ### Search Result More Info
+<img width="286" alt="image" src="https://user-images.githubusercontent.com/29545937/156363058-31d4b63e-2676-418b-9a94-4508b42f5a5a.png">
+
+### Right Info Panel
+<img width="529" alt="image" src="https://user-images.githubusercontent.com/29545937/156363180-5b7801da-388c-4108-b72d-5c36c98f62dc.png">


### PR DESCRIPTION
Add images for out-of-scope modules.

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/29545937/156363735-f519dac3-19fe-4bd7-ba25-61e85c03657c.png">
